### PR TITLE
mono16 support, scaling up to max range

### DIFF
--- a/hand_eye_calibration_target_extractor/src/target_extractor.cc
+++ b/hand_eye_calibration_target_extractor/src/target_extractor.cc
@@ -132,15 +132,13 @@ int main(int argc, char** argv) {
       img.data = image_message->data;
       img.encoding = "mono16";
 
-      // scale up the image to take use of the full 16bit range before encoding
-      // it to 8bit range
+      // Scale up the image to take use of the full 16bit range before encoding
+      // it to 8bit range.
       cv_bridge::CvImagePtr cv_ptr_tmp;
       cv_ptr_tmp =
           cv_bridge::toCvCopy(img, sensor_msgs::image_encodings::MONO16);
-      double min, max;
-      cv::minMaxLoc(cv_ptr_tmp->image, &min, &max);
-      double scaling_factor = 65535 / max;
-      cv_ptr_tmp->image = scaling_factor * cv_ptr_tmp->image;
+      cv::normalize(cv_ptr_tmp->image, cv_ptr_tmp->image, 0,
+                    std::numeric_limits<uint16_t>::max(), cv::NORM_MINMAX);
       cv_ptr_tmp->toImageMsg(img);
 
       cv_bridge::CvImageConstPtr cv_ptr;

--- a/hand_eye_calibration_target_extractor/src/target_extractor.cc
+++ b/hand_eye_calibration_target_extractor/src/target_extractor.cc
@@ -121,7 +121,8 @@ int main(int argc, char** argv) {
 
     // Convert image to cv::Mat.
     cv::Mat image;
-    if (image_message->encoding == "16UC1") {
+    if ((image_message->encoding == "16UC1") ||
+        (image_message->encoding == "mono16")) {
       sensor_msgs::Image img;
       img.header = image_message->header;
       img.height = image_message->height;
@@ -130,6 +131,17 @@ int main(int argc, char** argv) {
       img.step = image_message->step;
       img.data = image_message->data;
       img.encoding = "mono16";
+
+      // scale up the image to take use of the full 16bit range before encoding
+      // it to 8bit range
+      cv_bridge::CvImagePtr cv_ptr_tmp;
+      cv_ptr_tmp =
+          cv_bridge::toCvCopy(img, sensor_msgs::image_encodings::MONO16);
+      double min, max;
+      cv::minMaxLoc(cv_ptr_tmp->image, &min, &max);
+      double scaling_factor = 65535 / max;
+      cv_ptr_tmp->image = scaling_factor * cv_ptr_tmp->image;
+      cv_ptr_tmp->toImageMsg(img);
 
       cv_bridge::CvImageConstPtr cv_ptr;
       try {


### PR DESCRIPTION
- added handling of mono16 encoding format
- scaling up is needed for primesense IR camera because it produces very low value (max is ~1000) in 16bir range and then encoding it down to 8bit in handeyecalibration makes it mostly black.