### PR TITLE
Fix/dual quaternion to pose conversion.

### DIFF
--- a/hand_eye_calibration/python/hand_eye_calibration/dual_quaternion.py
+++ b/hand_eye_calibration/python/hand_eye_calibration/dual_quaternion.py
@@ -274,7 +274,7 @@ class DualQuaternion(object):
     q_rot = self.q_rot
     if (q_rot.w < 0.):
       q_rot = -q_rot
-    translation = (2.0 * self.q_dual) * q_rot.conjugate()
+    translation = (2.0 * self.q_dual) * self.q_rot.conjugate()
 
     pose[0:3] = translation.q[0:3].copy()
     pose[3:7] = q_rot.q.copy()

--- a/hand_eye_calibration/test/test_time_alignment.py
+++ b/hand_eye_calibration/test/test_time_alignment.py
@@ -39,7 +39,7 @@ class TimeAlignment(unittest.TestCase):
 
   # To generate varying angular velocities, we assign new random times
   # between the different quaternions.
-  quat_interpolate_times = np.random.rand(n_samples)
+  quat_interpolate_times = np.random.rand(int(n_samples))
   quat_interpolate_times.sort()
   quat_interpolate_times2 = (
       quat_interpolate_times *


### PR DESCRIPTION
### Problem Description

When extracting the pose vector `[x y z qx qy qz qw]` from the dual quaternion `[q_r, q_t]`, the method `DualQuaternion.to_pose()` first gets the rotation quaternion `q_r` and inverts its components in case the scalar part is negative (`q_r_minus`). This should be fine as it describes the same rotation. However, when extracting the translation vector `t` from the "translation quaternion" `q_t = 1/2 * t * q_r`, we need to use the exact same quaternion `q_r`. Using the `q_r_minus` for instead of `q_r` for the computation of `t` leads to an inverted translation vector. Is this correct?

### Summary

- Compute translation vector using `q_r` (which is `self.q_rot` in the code).
- Extend `test_conversions` unit test to also cover the case where the scalar part of the quaternion is negative.
- Use integer instead of float for index accessing (unrelated, but this unit test failed on my machine).